### PR TITLE
Include hidden course runs in publisher

### DIFF
--- a/src/data/services/DiscoveryDataApiService.js
+++ b/src/data/services/DiscoveryDataApiService.js
@@ -10,6 +10,7 @@ class DiscoveryDataApiService {
     const queryParams = {
       editable: 1,
       exclude_utm: 1,
+      include_hidden_course_runs: 1,
     };
     const url = `${discoveryBaseUrl}/courses/${uuid}/`;
     return getAuthenticatedHttpClient().get(url, {


### PR DESCRIPTION
Description: When a course visibility is set to 'none' or 'about', course goes away from both catalog page and publisher. Course should only go away from marketing site but not from publisher. Therefore, adding this parameter to keep all course runs visible in publisher